### PR TITLE
Fix Supabase news article creation error

### DIFF
--- a/src/components/NewsEditor.tsx
+++ b/src/components/NewsEditor.tsx
@@ -374,6 +374,31 @@ const NewsEditor: React.FC<NewsEditorProps> = ({ article, onSave, trigger }) => 
         table_of_contents: formData.table_of_contents || null,
         auto_generate_toc: formData.auto_generate_toc || false,
         toc_style: formData.toc_style || 'numbered',
+        // SEO関連フィールド
+        seo_title: formData.title?.substring(0, 60) || null,
+        meta_description: formData.summary?.substring(0, 160) || null,
+        meta_keywords: null,
+        slug: null, // 自動生成
+        canonical_url: null,
+        focus_keyword: null,
+        reading_time_minutes: null,
+        article_type: 'article',
+        author_name: 'Queue株式会社',
+        author_url: 'https://queue-tech.jp',
+        // Open Graph フィールド
+        og_title: formData.title?.substring(0, 95) || null,
+        og_description: formData.summary?.substring(0, 300) || null,
+        og_image: finalImageUrl || null,
+        og_type: 'article',
+        // Twitter Cards フィールド
+        twitter_title: formData.title?.substring(0, 70) || null,
+        twitter_description: formData.summary?.substring(0, 200) || null,
+        twitter_image: finalImageUrl || null,
+        twitter_card_type: 'summary_large_image',
+        // SEO管理フィールド
+        meta_robots: 'index, follow',
+        structured_data: null,
+        last_seo_update: now,
         status: formData.status,
         published_at: formData.status === 'published' ? now : null,
         updated_at: now

--- a/src/components/NewsEditorForm.tsx
+++ b/src/components/NewsEditorForm.tsx
@@ -597,6 +597,31 @@ const NewsEditorForm: React.FC<NewsEditorFormProps> = ({ article, onSave, onCanc
         table_of_contents: formData.table_of_contents || null,
         auto_generate_toc: formData.auto_generate_toc || false,
         toc_style: formData.toc_style || 'numbered',
+        // SEO関連フィールド
+        seo_title: formData.title?.substring(0, 60) || null,
+        meta_description: formData.summary?.substring(0, 160) || null,
+        meta_keywords: null,
+        slug: null, // 自動生成
+        canonical_url: null,
+        focus_keyword: null,
+        reading_time_minutes: null,
+        article_type: 'article',
+        author_name: 'Queue株式会社',
+        author_url: 'https://queue-tech.jp',
+        // Open Graph フィールド
+        og_title: formData.title?.substring(0, 95) || null,
+        og_description: formData.summary?.substring(0, 300) || null,
+        og_image: finalImageUrl || null,
+        og_type: 'article',
+        // Twitter Cards フィールド
+        twitter_title: formData.title?.substring(0, 70) || null,
+        twitter_description: formData.summary?.substring(0, 200) || null,
+        twitter_image: finalImageUrl || null,
+        twitter_card_type: 'summary_large_image',
+        // SEO管理フィールド
+        meta_robots: 'index, follow',
+        structured_data: null,
+        last_seo_update: now,
         status: formData.status,
         published_at: formData.status === 'published' ? now : null,
         updated_at: now

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -215,6 +215,31 @@ export interface Database {
           table_of_contents: any[] | null
           auto_generate_toc: boolean
           toc_style: 'numbered' | 'bulleted' | 'plain' | 'hierarchical'
+          // SEO関連フィールド
+          seo_title: string | null
+          meta_description: string | null
+          meta_keywords: string | null
+          slug: string | null
+          canonical_url: string | null
+          focus_keyword: string | null
+          reading_time_minutes: number | null
+          article_type: string
+          author_name: string
+          author_url: string
+          // Open Graph フィールド
+          og_title: string | null
+          og_description: string | null
+          og_image: string | null
+          og_type: string
+          // Twitter Cards フィールド
+          twitter_title: string | null
+          twitter_description: string | null
+          twitter_image: string | null
+          twitter_card_type: string
+          // SEO管理フィールド
+          meta_robots: string
+          structured_data: any | null
+          last_seo_update: string
           status: 'draft' | 'published' | 'archived'
           published_at: string | null
           created_at: string
@@ -232,6 +257,31 @@ export interface Database {
           table_of_contents?: any[] | null
           auto_generate_toc?: boolean
           toc_style?: 'numbered' | 'bulleted' | 'plain' | 'hierarchical'
+          // SEO関連フィールド
+          seo_title?: string | null
+          meta_description?: string | null
+          meta_keywords?: string | null
+          slug?: string | null
+          canonical_url?: string | null
+          focus_keyword?: string | null
+          reading_time_minutes?: number | null
+          article_type?: string
+          author_name?: string
+          author_url?: string
+          // Open Graph フィールド
+          og_title?: string | null
+          og_description?: string | null
+          og_image?: string | null
+          og_type?: string
+          // Twitter Cards フィールド
+          twitter_title?: string | null
+          twitter_description?: string | null
+          twitter_image?: string | null
+          twitter_card_type?: string
+          // SEO管理フィールド
+          meta_robots?: string
+          structured_data?: any | null
+          last_seo_update?: string
           status?: 'draft' | 'published' | 'archived'
           published_at?: string | null
           created_at?: string
@@ -249,6 +299,31 @@ export interface Database {
           table_of_contents?: any[] | null
           auto_generate_toc?: boolean
           toc_style?: 'numbered' | 'bulleted' | 'plain' | 'hierarchical'
+          // SEO関連フィールド
+          seo_title?: string | null
+          meta_description?: string | null
+          meta_keywords?: string | null
+          slug?: string | null
+          canonical_url?: string | null
+          focus_keyword?: string | null
+          reading_time_minutes?: number | null
+          article_type?: string
+          author_name?: string
+          author_url?: string
+          // Open Graph フィールド
+          og_title?: string | null
+          og_description?: string | null
+          og_image?: string | null
+          og_type?: string
+          // Twitter Cards フィールド
+          twitter_title?: string | null
+          twitter_description?: string | null
+          twitter_image?: string | null
+          twitter_card_type?: string
+          // SEO管理フィールド
+          meta_robots?: string
+          structured_data?: any | null
+          last_seo_update?: string
           status?: 'draft' | 'published' | 'archived'
           published_at?: string | null
           created_at?: string


### PR DESCRIPTION
Add missing SEO and social media metadata fields to article creation to resolve 400 Bad Request errors.

A recent database migration introduced several new `NOT NULL` SEO-related columns (e.g., `seo_title`, `meta_description`, `og_title`, `twitter_title`) to the `news_articles` table. The application was not providing values for these fields during article creation, leading to Supabase rejecting the insert operation. This PR populates these fields with sensible defaults or derived values from existing article data and updates the Supabase TypeScript types.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fe204b6-5b3c-4c87-8028-f8379ddeda20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3fe204b6-5b3c-4c87-8028-f8379ddeda20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

